### PR TITLE
fix: version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@opportify/sdk-nodejs",
   "author": "Opportify, Inc.",
   "description": "Opportify SDK for NodeJs",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this PR do?
Fix version number for `@opportify/sdk-nodejs` to be `0.1.0`

Package published: https://www.npmjs.com/package/@opportify/sdk-nodejs

## Why is this needed?
To align version across all of ours SDKs

## How did you implement it?
- Unpublished package in npm
- fixed version
- published a new version

## Are there any breaking changes?
No

## Testing Steps:
1. https://www.npmjs.com/package/@opportify/sdk-nodejs
