### PR TITLE
feat: improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,42 +28,52 @@ npm install --save @opportify/sdk-nodejs
 ### Calling Email Insights
 
 ```
-const { EmailInsights } = require('@opportify/sdk-nodejs');
+import { EmailInsights } from '@opportify/sdk-nodejs';
 
-const emailInsights = new EmailInsights({ 
+const clientEmailInsights = new EmailInsights({
   version: '1.0',
-  apiKey: 'YOUR-API-KEY-HERE'
+  apiKey: 'YOUR_API_KEY'
 });
 
-emailInsights.analyze({
-  email: 'your-test@email.domain.com',
-  enableAutoCorrection: true,
-  enableAI: true // only available for paid plans.
-}).then(response => {
-  console.log(response);  
-}).catch(error => {
-  console.error(error);
-});
+async function analyzeEmail() {
+  try {
+    const response = await clientEmailInsights.analyze({
+      email: "email_to_validate@domain.com",
+      enableAutoCorrection: true,
+      enableAI: true, // only available on paid plans.
+    });
+    console.log('response', response);
+  } catch (error: unknown) {
+    console.error('error', error);
+  }
+}
+
+analyzeEmail();
 ```
 
 ### Calling IP Insights
 
 ```
-const { IPInsights } = require('@opportify/sdk-nodejs');
+import { IPInsights } from '@opportify/sdk-nodejs';
 
-const ipInsights = new IPInsights({ 
+const clientIpInsights = new IPInsights({ 
   version: '1.0',
   apiKey: 'YOUR-API-KEY-HERE'
 });
 
-ipInsights.analyze({
-  ip: '8.8.8.8',
-  enableAI: true // only available for paid plans.
-}).then(response => {
-  console.log(response);  
-}).catch(error => {
-  console.error(error);
-});
+async function analyzeIP() {
+  try {
+    const response = await clientIpInsights.analyze({
+      ip: '8.8.8.8',
+      enableAI: true // only available for paid plans.
+    });
+    console.log('response', response);
+  } catch (error: unknown) {
+    console.error('error', error);
+  }
+}
+
+analyzeIP();
 ```
 
 ## About this package

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@opportify/sdk-nodejs",
   "author": "Opportify, Inc.",
   "description": "Opportify SDK for NodeJs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/emailInsights.ts
+++ b/src/emailInsights.ts
@@ -1,12 +1,7 @@
+import { ErrorResponse } from './types';
 import { EmailInsightsApi } from '../lib/v1/apis/EmailInsightsApi';
 import { AnalyzeEmailRequest } from '../lib/v1/models/AnalyzeEmailRequest';
 import { Configuration } from '../lib/v1/runtime';
-
-export type EmailInsightsConfiguration = {
-    apiKey: string;
-    version: string;
-    basePath?: string;
-};
 
 export class EmailInsights {
   private emailInsightsApi: EmailInsightsApi;
@@ -20,12 +15,17 @@ export class EmailInsights {
   }
 
   public async analyze (request: AnalyzeEmailRequest) {
-    return this.emailInsightsApi.analyzeEmail({
-        analyzeEmailRequest: {
-            email: request.email,
-            enableAutoCorrection: request.enableAutoCorrection,
-            enableAI: request.enableAI,
-        }
-    });
+    try {
+        return this.emailInsightsApi.analyzeEmail({
+            analyzeEmailRequest: {
+                email: request.email,
+                enableAutoCorrection: request.enableAutoCorrection,
+                enableAI: request.enableAI,
+            }
+        });
+    } catch (error) {
+        const errorResponse = await error.response.json() as ErrorResponse;
+        throw errorResponse;
+    }
   };
 }

--- a/src/emailInsights.ts
+++ b/src/emailInsights.ts
@@ -16,7 +16,7 @@ export class EmailInsights {
 
   public async analyze (request: AnalyzeEmailRequest) {
     try {
-        return this.emailInsightsApi.analyzeEmail({
+        return await this.emailInsightsApi.analyzeEmail({
             analyzeEmailRequest: {
                 email: request.email,
                 enableAutoCorrection: request.enableAutoCorrection,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-export { type EmailInsightsConfiguration, EmailInsights } from './emailInsights';
+export { EmailInsights } from './emailInsights';
 export { type AnalyzeEmailRequest } from '../lib/v1/models/AnalyzeEmailRequest';
-export { type IPInsightsConfiguration, IPInsights } from './ipInsights';
+export { IPInsights } from './ipInsights';
 export { type AnalyzeIpRequest } from '../lib/v1/models/AnalyzeIpRequest';
+export { type Configuration } from '../lib/v1/runtime';
+export { type ErrorResponse } from './types';

--- a/src/ipInsights.ts
+++ b/src/ipInsights.ts
@@ -1,12 +1,7 @@
 import { IPInsightsApi } from '../lib/v1/apis/IPInsightsApi';
 import { AnalyzeIpRequest } from '../lib/v1/models/AnalyzeIpRequest';
 import { Configuration } from '../lib/v1/runtime';
-
-export type IPInsightsConfiguration = {
-    apiKey: string;
-    version: string;
-    basePath?: string;
-};
+import { ErrorResponse } from './types';
 
 export class IPInsights {
   private ipInsightsApi: IPInsightsApi;
@@ -20,11 +15,16 @@ export class IPInsights {
   }
 
   public async analyze (request: AnalyzeIpRequest) {
-    return this.ipInsightsApi.analyzeIp({
-        analyzeIpRequest: {
-            ip: request.ip,
-            enableAI: request.enableAI,
-        }
-    });
+    try {
+        return this.ipInsightsApi.analyzeIp({
+            analyzeIpRequest: {
+                ip: request.ip,
+                enableAI: request.enableAI,
+            }
+        });
+    } catch (error) {
+        const errorResponse = await error.response.json() as ErrorResponse;
+        throw errorResponse;
+    }
   };
 }

--- a/src/ipInsights.ts
+++ b/src/ipInsights.ts
@@ -16,7 +16,7 @@ export class IPInsights {
 
   public async analyze (request: AnalyzeIpRequest) {
     try {
-        return this.ipInsightsApi.analyzeIp({
+        return await this.ipInsightsApi.analyzeIp({
             analyzeIpRequest: {
                 ip: request.ip,
                 enableAI: request.enableAI,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type ErrorResponse = {
+    errorCode: string;
+    errorMessage: string;
+}


### PR DESCRIPTION
## What does this PR do?
Improve SDK error handling 

## Why is this needed?
To avoid extra steps for customer to troubleshoot the API error response

## How did you implement it?
- added try-catch and return just error response from the API

## Are there any breaking changes?
No

## Testing Steps:
1. Checkout this branch
2. `npm run build`
