### PR TITLE
fix: action publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm build
+      - run: npm run build
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What does this PR do?
Fix the new GitHub workflow to publish to github. Action failed for the last version.

```
Unknown command: "build"
```

## Why is this needed?
This is to publish to NPMJS automatically once we publish a new release.

## How did you implement it?
- Fixed the command

## Are there any breaking changes?
No.
