### PR TITLE
feat: expose response types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export { IPInsights } from './ipInsights';
 export { type AnalyzeIpRequest } from '../lib/v1/models/AnalyzeIpRequest';
 export { type Configuration } from '../lib/v1/runtime';
 export { type ErrorResponse } from './types';
+export type { AnalyzeEmail200Response } from '../lib/v1/models/AnalyzeEmail200Response';
+export type { AnalyzeIp200Response } from '../lib/v1/models/AnalyzeIp200Response';


### PR DESCRIPTION
## What does this PR do?
Expose response types so we can properly use typing in typescript lambda code.

## Why is this needed?
To improve code written in typescript for integrations that use our SDK.

## How did you implement it?
- Exposed types AnalyzeEmail200Response and AnalyzeIp200Response

## Are there any breaking changes?
No

## Testing Steps:
1. Checkout this branch
2. `npm run build`