### PR TITLE
fix: error handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@opportify/sdk-nodejs",
   "author": "Opportify, Inc.",
   "description": "Opportify SDK for NodeJs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/emailInsights.ts
+++ b/src/emailInsights.ts
@@ -1,8 +1,8 @@
-import { ErrorResponse } from './types';
 import { CreateEmailBatchExportRequest, EmailInsightsApi, GetEmailBatchExportStatusRequest, GetEmailBatchStatusRequest } from '../lib/v1/apis/EmailInsightsApi';
-import { AnalyzeEmailRequest  } from '../lib/v1/models/AnalyzeEmailRequest';
+import { AnalyzeEmailRequest } from '../lib/v1/models/AnalyzeEmailRequest';
 import { Configuration } from '../lib/v1/runtime';
 import { BatchAnalyzeEmailsRequest } from '../lib/v1/models/BatchAnalyzeEmailsRequest';
+import { toErrorResponse } from './errorUtils';
 
 export class EmailInsights {
   private emailInsightsApi: EmailInsightsApi;
@@ -21,8 +21,7 @@ export class EmailInsights {
             analyzeEmailRequest: request
         });
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
 
@@ -32,8 +31,7 @@ export class EmailInsights {
             batchAnalyzeEmailsRequest: request
         });
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
   
@@ -41,8 +39,7 @@ export class EmailInsights {
     try {
         return await this.emailInsightsApi.getEmailBatchStatus(request);
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
 
@@ -50,8 +47,7 @@ export class EmailInsights {
     try {
         return await this.emailInsightsApi.createEmailBatchExport(request);
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
 
@@ -59,8 +55,7 @@ export class EmailInsights {
     try {
         return await this.emailInsightsApi.getEmailBatchExportStatus(request);
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
 }

--- a/src/errorUtils.ts
+++ b/src/errorUtils.ts
@@ -78,9 +78,10 @@ export const toErrorResponse = async (error: unknown): Promise<ErrorResponse> =>
   if (error && typeof error === 'object') {
     const response = (error as { response?: Response }).response;
     if (response) {
+      const statusText = response.statusText?.trim();
       const fallback: ErrorResponse = {
         errorCode: normalizeFallbackCode(response.status),
-        errorMessage: response.statusText?.trim().length ? response.statusText : DEFAULT_ERROR_MESSAGE,
+        errorMessage: statusText && statusText.length > 0 ? statusText : DEFAULT_ERROR_MESSAGE,
       };
 
       const jsonPayload = await parseJsonSafely(response);

--- a/src/errorUtils.ts
+++ b/src/errorUtils.ts
@@ -1,0 +1,112 @@
+import { ErrorResponse } from './types';
+
+const DEFAULT_ERROR_MESSAGE = 'Request failed';
+
+const isErrorResponse = (payload: unknown): payload is ErrorResponse => {
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+  const record = payload as Record<string, unknown>;
+  return typeof record.errorCode === 'string' && typeof record.errorMessage === 'string';
+};
+
+const pickField = (payload: Record<string, unknown>, candidates: string[]): string | undefined => {
+  for (const field of candidates) {
+    const value = payload[field];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const normalizeFallbackCode = (status?: number): string => {
+  if (typeof status === 'number' && Number.isFinite(status)) {
+    return `HTTP_${status}`;
+  }
+  return 'HTTP_UNKNOWN';
+};
+
+const normalizeJsonPayload = (
+  payload: unknown,
+  fallbackCode: string,
+  fallbackMessage: string,
+): ErrorResponse | undefined => {
+  if (isErrorResponse(payload)) {
+    return payload;
+  }
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    const errorCode = pickField(record, ['errorCode', 'code']) || fallbackCode;
+    const errorMessage = pickField(record, ['errorMessage', 'message', 'detail', 'description']);
+    if (errorMessage) {
+      return { errorCode, errorMessage };
+    }
+    try {
+      const serialized = JSON.stringify(payload);
+      if (serialized && serialized !== '{}') {
+        return { errorCode, errorMessage: serialized };
+      }
+    } catch (serializationError) {
+      // no-op; fall through to fallback response
+    }
+  }
+  if (typeof payload === 'string' && payload.trim().length > 0) {
+    return { errorCode: fallbackCode, errorMessage: payload };
+  }
+  return undefined;
+};
+
+const parseJsonSafely = async (response: Response): Promise<unknown | undefined> => {
+  try {
+    return await response.clone().json();
+  } catch (error) {
+    return undefined;
+  }
+};
+
+const parseTextSafely = async (response: Response): Promise<string | undefined> => {
+  try {
+    const text = await response.clone().text();
+    return text.trim().length > 0 ? text : undefined;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export const toErrorResponse = async (error: unknown): Promise<ErrorResponse> => {
+  if (error && typeof error === 'object') {
+    const response = (error as { response?: Response }).response;
+    if (response) {
+      const fallback: ErrorResponse = {
+        errorCode: normalizeFallbackCode(response.status),
+        errorMessage: response.statusText?.trim().length ? response.statusText : DEFAULT_ERROR_MESSAGE,
+      };
+
+      const jsonPayload = await parseJsonSafely(response);
+      const normalizedFromJson = normalizeJsonPayload(jsonPayload, fallback.errorCode, fallback.errorMessage);
+      if (normalizedFromJson) {
+        return normalizedFromJson;
+      }
+
+      const textPayload = await parseTextSafely(response);
+      if (textPayload) {
+        return { errorCode: fallback.errorCode, errorMessage: textPayload };
+      }
+
+      return fallback;
+    }
+
+    if (error instanceof Error) {
+      return {
+        errorCode: 'REQUEST_ERROR',
+        errorMessage: error.message || DEFAULT_ERROR_MESSAGE,
+      };
+    }
+  }
+
+  return {
+    errorCode: 'UNKNOWN_ERROR',
+    errorMessage: DEFAULT_ERROR_MESSAGE,
+  };
+};

--- a/src/errorUtils.ts
+++ b/src/errorUtils.ts
@@ -57,6 +57,7 @@ const normalizeJsonPayload = (
   return undefined;
 };
 
+// Clone the response before reading so callers can still access the original body stream.
 const parseJsonSafely = async (response: Response): Promise<unknown | undefined> => {
   try {
     return await response.clone().json();
@@ -65,6 +66,7 @@ const parseJsonSafely = async (response: Response): Promise<unknown | undefined>
   }
 };
 
+// Clone again for text parsing to avoid exhausting the main response body.
 const parseTextSafely = async (response: Response): Promise<string | undefined> => {
   try {
     const text = await response.clone().text();

--- a/src/ipInsights.ts
+++ b/src/ipInsights.ts
@@ -2,7 +2,7 @@ import { CreateIpBatchExportRequest, GetIpBatchExportStatusRequest, GetIpBatchSt
 import { AnalyzeIpRequest } from '../lib/v1/models/AnalyzeIpRequest';
 import { BatchAnalyzeIpsRequest } from '../lib/v1/models/BatchAnalyzeIpsRequest';
 import { Configuration } from '../lib/v1/runtime';
-import { ErrorResponse } from './types';
+import { toErrorResponse } from './errorUtils';
 
 export class IPInsights {
   private ipInsightsApi: IPInsightsApi;
@@ -24,8 +24,7 @@ export class IPInsights {
             }
         });
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
 
@@ -38,8 +37,7 @@ export class IPInsights {
             }
         });
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
 
@@ -47,26 +45,23 @@ export class IPInsights {
     try {
         return await this.ipInsightsApi.getIpBatchStatus(request);
     } catch (error) {
-        const errorResponse = await error.response.json() as ErrorResponse;
-        throw errorResponse;
+        throw await toErrorResponse(error);
     }
   };
   
-    public async createIpBatchExport (request: CreateIpBatchExportRequest) {
-      try {
-          return await this.ipInsightsApi.createIpBatchExport(request);
-      } catch (error) {
-          const errorResponse = await error.response.json() as ErrorResponse;
-          throw errorResponse;
-      }
-    };
+  public async createIpBatchExport (request: CreateIpBatchExportRequest) {
+    try {
+        return await this.ipInsightsApi.createIpBatchExport(request);
+    } catch (error) {
+        throw await toErrorResponse(error);
+    }
+  };
 
-    public async getIpBatchExportStatus (request: GetIpBatchExportStatusRequest ) {
-      try {
-          return await this.ipInsightsApi.getIpBatchExportStatus(request);
-      } catch (error) {
-          const errorResponse = await error.response.json() as ErrorResponse;
-          throw errorResponse;
-      }
-    };
+  public async getIpBatchExportStatus (request: GetIpBatchExportStatusRequest ) {
+    try {
+        return await this.ipInsightsApi.getIpBatchExportStatus(request);
+    } catch (error) {
+        throw await toErrorResponse(error);
+    }
+  };
 }


### PR DESCRIPTION
This pull request improves error handling in both the `EmailInsights` and `IPInsights` classes by introducing a new utility function to standardize error responses. Instead of manually parsing error responses in each API method, the code now uses a shared `toErrorResponse` utility, making error handling more robust and maintainable. Additionally, the package version is bumped to reflect these improvements.

**Error handling improvements:**

* Introduced a new `toErrorResponse` utility in `src/errorUtils.ts` that normalizes errors from API responses, including handling for various payload formats and fallback scenarios.
* Updated all error handling in `src/emailInsights.ts` and `src/ipInsights.ts` to use the new `toErrorResponse` function, replacing repetitive error parsing logic with a single call. This affects all methods that interact with the API in both classes. [[1]](diffhunk://#diff-be3cd2f86af063fe1cea73c44450ba269eac2974feb6776d867cb4c36a1f978fL1-R5) [[2]](diffhunk://#diff-be3cd2f86af063fe1cea73c44450ba269eac2974feb6776d867cb4c36a1f978fL24-R24) [[3]](diffhunk://#diff-be3cd2f86af063fe1cea73c44450ba269eac2974feb6776d867cb4c36a1f978fL35-R58) [[4]](diffhunk://#diff-5053204a0284f0b9d39ad2af9ec24ef7895606c735bf1558082183090262430cL5-R5) [[5]](diffhunk://#diff-5053204a0284f0b9d39ad2af9ec24ef7895606c735bf1558082183090262430cL27-R27) [[6]](diffhunk://#diff-5053204a0284f0b9d39ad2af9ec24ef7895606c735bf1558082183090262430cL41-R64)

**Versioning:**

* Bumped the package version from `0.6.0` to `0.6.1` in `package.json` to reflect these changes.