### PR TITLE
chore: add iTerm2 tab config

### DIFF
--- a/.iterm2tab
+++ b/.iterm2tab
@@ -1,0 +1,2 @@
+name=opportify-sdk-nodejs
+color=#68A063


### PR DESCRIPTION
## Summary

Adds a `.iterm2tab` file to configure automatic iTerm2 tab name and color when entering this project directory.

## How it works

A zsh hook reads the nearest `.iterm2tab` file walking up the directory tree on every `cd` and prompt, then applies the tab name and color via iTerm2 escape sequences.

Run the setup script once to install the hook:
```bash
bash ~/Projects/opportify/local-aws-resources/scripts/setup-iterm2-tabs.sh
```

## `.iterm2tab` format
```ini
name=<repo-name>
color=#RRGGBB
```