### PR TITLE
fix: migrate ts-jest config from deprecated globals to transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,8 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "testMatch": ["**/test/**/*.test.ts"],
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.test.json"
-      }
+    "transform": {
+      "^.+\\.tsx?$": ["ts-jest", { "tsconfig": "tsconfig.test.json" }]
     },
     "moduleNameMapper": {
       "^node-fetch$": "<rootDir>/node_modules/node-fetch/src/index.js"


### PR DESCRIPTION
## Problem

Running `npm test` emits repeated deprecation warnings from ts-jest:

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated.
```

## Fix

Move the `tsconfig` option out of Jest's `globals` key and into the `transform` map, as required by ts-jest v29+:

```json
"transform": {
  "^.+\.tsx?$": ["ts-jest", { "tsconfig": "tsconfig.test.json" }]
}
```

## Verification

All 39 tests pass with zero warnings.