### PR TITLE
fix: sync package version from release tag before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: Set version from release tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          npm version "$VERSION" --no-git-tag-version
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Problem

The publish workflow was not updating `package.json` version to match the GitHub release tag. This caused it to attempt re-publishing a previously released version (e.g. `0.6.1` when the release was `v0.7.0`), resulting in a 404 error from the npm registry:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@opportify%2fsdk-nodejs - Not found
npm error 404  '@opportify/sdk-nodejs@0.6.1' is not in this registry.
```

## Fix

Added a **Set version from release tag** step that:
1. Reads `github.event.release.tag_name` (e.g. `v0.7.0`)
2. Strips the `v` prefix → `0.7.0`
3. Runs `npm version "$VERSION" --no-git-tag-version` to update `package.json` before build & publish

This ensures the published npm version always matches the GitHub release tag.