### PR TITLE
chore: set minimum Node.js engine requirement to >=20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ai"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Node 18 reached end-of-life in April 2025. This bumps the minimum declared engine to Node 20, which aligns with the CI matrix introduced in #20.