### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opportify/sdk-nodejs",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opportify/sdk-nodejs",
-      "version": "0.6.1",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@opportify/sdk-nodejs",
   "author": "Opportify, Inc.",
   "description": "Opportify SDK for NodeJs",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -64,7 +64,9 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "testMatch": ["**/test/**/*.test.ts"],
+    "testMatch": [
+      "**/test/**/*.test.ts"
+    ],
     "globals": {
       "ts-jest": {
         "tsconfig": "tsconfig.test.json"


### PR DESCRIPTION
Bumps `package.json` and `package-lock.json` to version `0.7.1`.