### PR TITLE
fix: skip version bump in publish workflow if already up to date

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,12 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
-          npm version "$VERSION" --no-git-tag-version
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$CURRENT" != "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+          else
+            echo "package.json already at $VERSION, skipping version bump"
+          fi
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public


### PR DESCRIPTION
The publish workflow was crashing when `package.json` already matched the release tag version:

```
npm error Version not changed
```

The `Set version from release tag` step now reads the current version from `package.json` and only calls `npm version` when it differs from the tag. If they already match, the step logs a message and continues to build and publish normally.