### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opportify/sdk-nodejs",
-  "version": "0.7.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opportify/sdk-nodejs",
-      "version": "0.7.2",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@opportify/sdk-nodejs",
   "author": "Opportify, Inc.",
   "description": "Opportify SDK for NodeJs",
-  "version": "0.7.2",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this PR do?
Bumps the package version from `0.7.2` to `1.0.0`, marking the SDK as stable and well-tested.

## Why is this needed?
The SDK is stable and well-tested, warranting a v1.0.0 major release per Semantic Versioning.

## How did you implement it?
Updated the `version` field in `package.json` from `0.7.2` to `1.0.0`.

## Breaking changes?
No breaking changes — this is a version number update only.

## Testing steps
1. `npm run build` — verify build succeeds
2. `npm test` — verify all tests pass
3. Confirm `package.json` version reads `1.0.0`

## Related issues
N/A